### PR TITLE
Many improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,7 @@ target_sources(sio PUBLIC
     source/sio/io_uring/socket_handle.hpp
     source/sio/assert.hpp
     source/sio/async_allocator.hpp
+    source/sio/async_mutex.hpp
     source/sio/async_resource.hpp
     source/sio/concepts.hpp
     source/sio/deferred.hpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,7 @@ target_sources(sio PUBLIC
     source/sio/io_uring/socket_handle.hpp
     source/sio/assert.hpp
     source/sio/async_allocator.hpp
+    source/sio/async_channel.hpp
     source/sio/async_mutex.hpp
     source/sio/async_resource.hpp
     source/sio/concepts.hpp

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -12,5 +12,5 @@ endif ()
 add_executable(echo_standard_input echo_standard_input.cpp)
 target_link_libraries(echo_standard_input PRIVATE sio::sio)
 
-add_executable(tcp_echo_server tcp_echo_server.cpp)
-target_link_libraries(tcp_echo_server PRIVATE sio::sio)
+# add_executable(tcp_echo_server tcp_echo_server.cpp)
+# target_link_libraries(tcp_echo_server PRIVATE sio::sio)

--- a/examples/tcp_echo_server.cpp
+++ b/examples/tcp_echo_server.cpp
@@ -42,15 +42,13 @@ auto echo_input(tcp_socket client) {
 
 int main() {
   exec::io_uring_context context{};
-  auto acceptor = sio::io_uring::make_deferred_acceptor(
+  auto acceptor = sio::io_uring::acceptor(
     &context, sio::ip::tcp::v4(), sio::ip::endpoint{sio::ip::address_v4::any(), 1080});
 
   auto accept_connections = sio::async::use_resources(
     [&](tcp_acceptor acceptor) {
       return sio::async::accept(acceptor) //
-           | sio::let_value_each([](tcp_socket client) {
-               return echo_input(client);
-             })
+           | sio::let_value_each([](tcp_socket client) { return echo_input(client); })
            | sio::ignore_all();
     },
     acceptor);

--- a/source/sio/async_channel.hpp
+++ b/source/sio/async_channel.hpp
@@ -1,0 +1,265 @@
+/*
+ * Copyright (c) 2023 Maikel Nadolski
+ *
+ * Licensed under the Apache License Version 2.0 with LLVM Exceptions
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *   https://llvm.org/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "./async_mutex.hpp"
+#include "./async_resource.hpp"
+#include "./deferred.hpp"
+
+#include "./intrusive_list.hpp"
+#include "./sequence/any_sequence_of.hpp"
+
+#include <exec/async_scope.hpp>
+
+namespace sio {
+  namespace channel_ {
+    struct observer {
+      any_sequence_receiver_ref<stdexec::completion_signatures<stdexec::set_value_t()>> receiver;
+      observer* prev = nullptr;
+      observer* next = nullptr;
+      std::atomic<bool> started_;
+    };
+
+    struct context {
+      async_mutex mutex_{};
+      intrusive_list<&observer::prev, &observer::next> observers_{};
+      exec::async_scope scope_{};
+    };
+
+    struct handle_base {
+      context* resource;
+
+      template <class Item>
+      auto notify_all(Item item) {
+        return stdexec::let_value(
+          stdexec::when_all(stdexec::just(std::move(item)), resource->mutex_.lock()),
+          [resource = resource](const Item& item) {
+            for (observer& o: resource->observers_) {
+              resource->scope_.spawn(
+                exec::set_next(o.receiver, item) //
+                | stdexec::upon_stopped([resource, &o] {
+                    resource->observers_.erase(&o);
+                    stdexec::set_value(std::move(o.receiver));
+                  }));
+            }
+            return resource->scope_.on_empty();
+          });
+      }
+
+      auto unsubscribe(observer* o) {
+        return stdexec::then(resource->mutex_.lock(), [resource = resource, o]() noexcept {
+          resource->observers_.erase(o);
+          stdexec::set_value(std::move(o->receiver));
+        });
+      }
+
+      auto subscribe(observer* o) {
+        return stdexec::then(resource->mutex_.lock(), [resource = resource, o]() noexcept {
+          o->started_.store(true, std::memory_order_relaxed);
+          resource->observers_.push_back(o);
+        });
+      }
+
+      auto close() const {
+        return stdexec::let_value(resource->mutex_.lock(), [resource = resource]() noexcept {
+          while (!resource->observers_.empty()) {
+            observer* o = resource->observers_.pop_front();
+            stdexec::set_value(std::move(o->receiver));
+          }
+          return resource->scope_.on_empty();
+        });
+      }
+    };
+
+    template <class Receiver>
+    struct subscribe_operation;
+
+    template <class Receiver>
+    struct on_stop_requested {
+      subscribe_operation<Receiver>* op_;
+      void operator()() const noexcept;
+    };
+
+    template <class Receiver>
+    struct wrap_receiver {
+      using is_receiver = void;
+      subscribe_operation<Receiver>* op_;
+      stdexec::env_of_t<Receiver> get_env(stdexec::get_env_t) const noexcept;
+
+      template <class Sender>
+      exec::next_sender_of_t<Receiver, Sender> set_next(exec::set_next_t, Sender&& sndr);
+      void set_value(stdexec::set_value_t) && noexcept;
+    };
+
+    template <class Receiver>
+    struct stop_receiver {
+      using is_receiver = void;
+      subscribe_operation<Receiver>* op_;
+
+      stdexec::empty_env get_env(stdexec::get_env_t) const noexcept {
+        return {};
+      }
+
+      void set_value(stdexec::set_value_t) && noexcept;
+    };
+
+    struct nop_receiver {
+      using is_receiver = void;
+
+      stdexec::empty_env get_env(stdexec::get_env_t) const noexcept {
+        return {};
+      }
+
+      void set_value(stdexec::set_value_t) const noexcept {
+      }
+    };
+
+    using notify_sender_t = decltype(std::declval<handle_base>().notify_all());
+
+    using subscribe_sender_t =
+      decltype(std::declval<handle_base>().subscribe(std::declval<observer*>()));
+
+    using stop_sender_t =
+      decltype(std::declval<handle_base>().unsubscribe(std::declval<observer*>()));
+
+    template <class Receiver>
+    struct subscribe_operation {
+      Receiver rcvr_;
+      wrap_receiver<Receiver> wrapped_receiver_;
+      observer observer_;
+      handle_base channel_;
+      stdexec::connect_result_t<subscribe_sender_t, nop_receiver> subscribe_operation_;
+      stdexec::connect_result_t<stop_sender_t, stop_receiver<Receiver>> stop_operation_;
+      using stop_token = stdexec::stop_token_of_t<stdexec::env_of_t<Receiver>>;
+      using callback_type =
+        typename stop_token::template callback_type<on_stop_requested<Receiver>>;
+      std::atomic<int> n_ops_{0};
+      std::optional<callback_type> callback_{};
+
+      subscribe_operation(Receiver&& rcvr, handle_base channel)
+        : rcvr_(std::move(rcvr))
+        , wrapped_receiver_{this}
+        , observer_{wrapped_receiver_}
+        , channel_{channel}
+        , subscribe_operation_{stdexec::connect(channel_.subscribe(&observer_), nop_receiver{})}
+        , stop_operation_{
+            stdexec::connect(channel_.unsubscribe(&observer_), stop_receiver<Receiver>{this})} {
+      }
+
+      void start(stdexec::start_t) noexcept {
+        // TODO racy
+        callback_.emplace(
+          stdexec::get_stop_token(stdexec::get_env(rcvr_)), on_stop_requested{this});
+        int expected = 0;
+        if (n_ops_.compare_exchange_strong(expected, 1, std::memory_order_relaxed)) {
+          stdexec::start(subscribe_operation_);
+        }
+      }
+    };
+
+    template <class Receiver>
+    void on_stop_requested<Receiver>::operator()() const noexcept {
+      int before = op_->n_ops_.exchange(2, std::memory_order_relaxed);
+      if (before == 1) {
+        stdexec::start(op_->stop_operation_);
+      } else if (before == 0) {
+        op_->callback_.reset();
+        stdexec::set_value(std::move(op_->rcvr_));
+      }
+    }
+
+    template <class Receiver>
+    stdexec::env_of_t<Receiver>
+      wrap_receiver<Receiver>::get_env(stdexec::get_env_t) const noexcept {
+      return stdexec::get_env(op_->rcvr_);
+    }
+
+    template <class Receiver>
+    template <class Sender>
+    exec::next_sender_of_t<Receiver, Sender>
+      wrap_receiver<Receiver>::set_next(exec::set_next_t, Sender&& sndr) {
+      return exec::set_next(op_->rcvr_, std::forward<Sender>(sndr));
+    }
+
+    template <class Receiver>
+    void wrap_receiver<Receiver>::set_value(stdexec::set_value_t) && noexcept {
+      int before = op_->n_ops_.exchange(3, std::memory_order_relaxed);
+      if (before == 1) {
+        op_->callback_.reset();
+        stdexec::set_value(std::move(op_->rcvr_));
+      }
+    }
+
+    template <class Receiver>
+    void stop_receiver<Receiver>::set_value(stdexec::set_value_t) && noexcept {
+      stdexec::set_value(std::move(op_->rcvr_));
+    }
+
+    struct subscribe_sequence {
+      using is_sender = exec::sequence_tag;
+      using completion_signatures = stdexec::completion_signatures<stdexec::set_value_t()>;
+
+      template <class Receiver>
+      auto subscribe(exec::subscribe_t, Receiver rcvr) const noexcept
+        -> subscribe_operation<Receiver> {
+        return {std::move(rcvr), channel_};
+      }
+
+      handle_base channel_;
+    };
+
+    class channel;
+
+    class handle {
+     private:
+      handle_base base_;
+
+      friend class channel;
+
+      explicit handle(context& ctx)
+        : base_{&ctx} {
+      }
+
+      friend class async::close_t;
+
+      auto close(async::close_t) const {
+        return base_.close();
+      }
+
+     public:
+      notify_sender_t notify_all() {
+        return base_.notify_all();
+      }
+
+      subscribe_sequence subscribe() const noexcept {
+        return {base_};
+      }
+    };
+
+    struct channel {
+      auto open(async::open_t) const {
+        return stdexec::let_value(
+          stdexec::just(make_deferred<context>()), [this](auto& ctx) noexcept {
+            ctx();
+            return stdexec::just(handle{*ctx});
+          });
+      }
+    };
+  }
+
+  using async_channel = channel_::channel;
+  using async_channel_handle = channel_::handle;
+}

--- a/source/sio/async_channel.hpp
+++ b/source/sio/async_channel.hpp
@@ -21,33 +21,37 @@
 
 #include "./intrusive_list.hpp"
 #include "./sequence/any_sequence_of.hpp"
+#include "./sequence/ignore_all.hpp"
 
 #include <exec/async_scope.hpp>
 
 namespace sio {
   namespace channel_ {
+    template <class Completions>
     struct observer {
-      any_sequence_receiver_ref<stdexec::completion_signatures<stdexec::set_value_t()>> receiver;
+      any_sequence_receiver_ref<Completions> receiver;
       observer* prev = nullptr;
       observer* next = nullptr;
       std::atomic<bool> started_;
     };
 
+    template <class Completions>
     struct context {
       async_mutex mutex_{};
-      intrusive_list<&observer::prev, &observer::next> observers_{};
+      intrusive_list<&observer<Completions>::prev, &observer<Completions>::next> observers_{};
       exec::async_scope scope_{};
     };
 
+    template <class Completions>
     struct handle_base {
-      context* resource;
+      context<Completions>* resource;
 
       template <class Item>
-      auto notify_all(Item item) {
+      auto notify_all(Item item) const {
         return stdexec::let_value(
           stdexec::when_all(stdexec::just(std::move(item)), resource->mutex_.lock()),
           [resource = resource](const Item& item) {
-            for (observer& o: resource->observers_) {
+            for (observer<Completions>& o: resource->observers_) {
               resource->scope_.spawn(
                 exec::set_next(o.receiver, item) //
                 | stdexec::upon_stopped([resource, &o] {
@@ -59,14 +63,14 @@ namespace sio {
           });
       }
 
-      auto unsubscribe(observer* o) {
+      auto unsubscribe(observer<Completions>* o) const {
         return stdexec::then(resource->mutex_.lock(), [resource = resource, o]() noexcept {
           resource->observers_.erase(o);
           stdexec::set_value(std::move(o->receiver));
         });
       }
 
-      auto subscribe(observer* o) {
+      auto subscribe(observer<Completions>* o) const {
         return stdexec::then(resource->mutex_.lock(), [resource = resource, o]() noexcept {
           o->started_.store(true, std::memory_order_relaxed);
           resource->observers_.push_back(o);
@@ -76,7 +80,7 @@ namespace sio {
       auto close() const {
         return stdexec::let_value(resource->mutex_.lock(), [resource = resource]() noexcept {
           while (!resource->observers_.empty()) {
-            observer* o = resource->observers_.pop_front();
+            observer<Completions>* o = resource->observers_.pop_front();
             stdexec::set_value(std::move(o->receiver));
           }
           return resource->scope_.on_empty();
@@ -84,19 +88,19 @@ namespace sio {
       }
     };
 
-    template <class Receiver>
+    template <class Completions, class Receiver>
     struct subscribe_operation;
 
-    template <class Receiver>
+    template <class Completions, class Receiver>
     struct on_stop_requested {
-      subscribe_operation<Receiver>* op_;
+      subscribe_operation<Completions, Receiver>* op_;
       void operator()() const noexcept;
     };
 
-    template <class Receiver>
+    template <class Completions, class Receiver>
     struct wrap_receiver {
       using is_receiver = void;
-      subscribe_operation<Receiver>* op_;
+      subscribe_operation<Completions, Receiver>* op_;
       stdexec::env_of_t<Receiver> get_env(stdexec::get_env_t) const noexcept;
 
       template <class Sender>
@@ -104,10 +108,10 @@ namespace sio {
       void set_value(stdexec::set_value_t) && noexcept;
     };
 
-    template <class Receiver>
+    template <class Completions, class Receiver>
     struct stop_receiver {
       using is_receiver = void;
-      subscribe_operation<Receiver>* op_;
+      subscribe_operation<Completions, Receiver>* op_;
 
       stdexec::empty_env get_env(stdexec::get_env_t) const noexcept {
         return {};
@@ -127,40 +131,41 @@ namespace sio {
       }
     };
 
-    using notify_sender_t = decltype(std::declval<handle_base>().notify_all());
+    template <class Completions>
+    using subscribe_sender_t = decltype(std::declval<handle_base<Completions>>().subscribe(
+      std::declval<observer<Completions>*>()));
 
-    using subscribe_sender_t =
-      decltype(std::declval<handle_base>().subscribe(std::declval<observer*>()));
+    template <class Completions>
+    using stop_sender_t = decltype(std::declval<handle_base<Completions>>().unsubscribe(
+      std::declval<observer<Completions>*>()));
 
-    using stop_sender_t =
-      decltype(std::declval<handle_base>().unsubscribe(std::declval<observer*>()));
-
-    template <class Receiver>
+    template <class Completions, class Receiver>
     struct subscribe_operation {
       Receiver rcvr_;
-      wrap_receiver<Receiver> wrapped_receiver_;
-      observer observer_;
-      handle_base channel_;
-      stdexec::connect_result_t<subscribe_sender_t, nop_receiver> subscribe_operation_;
-      stdexec::connect_result_t<stop_sender_t, stop_receiver<Receiver>> stop_operation_;
+      wrap_receiver<Completions, Receiver> wrapped_receiver_;
+      observer<Completions> observer_;
+      handle_base<Completions> channel_;
+      stdexec::connect_result_t<subscribe_sender_t<Completions>, nop_receiver> subscribe_operation_;
+      stdexec::connect_result_t<stop_sender_t<Completions>, stop_receiver<Completions, Receiver>>
+        stop_operation_;
       using stop_token = stdexec::stop_token_of_t<stdexec::env_of_t<Receiver>>;
       using callback_type =
-        typename stop_token::template callback_type<on_stop_requested<Receiver>>;
+        typename stop_token::template callback_type<on_stop_requested<Completions, Receiver>>;
       std::atomic<int> n_ops_{0};
       std::optional<callback_type> callback_{};
 
-      subscribe_operation(Receiver&& rcvr, handle_base channel)
+      subscribe_operation(Receiver&& rcvr, handle_base<Completions> channel)
         : rcvr_(std::move(rcvr))
         , wrapped_receiver_{this}
         , observer_{wrapped_receiver_}
         , channel_{channel}
         , subscribe_operation_{stdexec::connect(channel_.subscribe(&observer_), nop_receiver{})}
-        , stop_operation_{
-            stdexec::connect(channel_.unsubscribe(&observer_), stop_receiver<Receiver>{this})} {
+        , stop_operation_{stdexec::connect(
+            channel_.unsubscribe(&observer_),
+            stop_receiver<Completions, Receiver>{this})} {
       }
 
       void start(stdexec::start_t) noexcept {
-        // TODO racy
         callback_.emplace(
           stdexec::get_stop_token(stdexec::get_env(rcvr_)), on_stop_requested{this});
         int expected = 0;
@@ -170,8 +175,8 @@ namespace sio {
       }
     };
 
-    template <class Receiver>
-    void on_stop_requested<Receiver>::operator()() const noexcept {
+    template <class Completions, class Receiver>
+    void on_stop_requested<Completions, Receiver>::operator()() const noexcept {
       int before = op_->n_ops_.exchange(2, std::memory_order_relaxed);
       if (before == 1) {
         stdexec::start(op_->stop_operation_);
@@ -181,21 +186,21 @@ namespace sio {
       }
     }
 
-    template <class Receiver>
+    template <class Completions, class Receiver>
     stdexec::env_of_t<Receiver>
-      wrap_receiver<Receiver>::get_env(stdexec::get_env_t) const noexcept {
+      wrap_receiver<Completions, Receiver>::get_env(stdexec::get_env_t) const noexcept {
       return stdexec::get_env(op_->rcvr_);
     }
 
-    template <class Receiver>
+    template <class Completions, class Receiver>
     template <class Sender>
     exec::next_sender_of_t<Receiver, Sender>
-      wrap_receiver<Receiver>::set_next(exec::set_next_t, Sender&& sndr) {
+      wrap_receiver<Completions, Receiver>::set_next(exec::set_next_t, Sender&& sndr) {
       return exec::set_next(op_->rcvr_, std::forward<Sender>(sndr));
     }
 
-    template <class Receiver>
-    void wrap_receiver<Receiver>::set_value(stdexec::set_value_t) && noexcept {
+    template <class Completions, class Receiver>
+    void wrap_receiver<Completions, Receiver>::set_value(stdexec::set_value_t) && noexcept {
       int before = op_->n_ops_.exchange(3, std::memory_order_relaxed);
       if (before == 1) {
         op_->callback_.reset();
@@ -203,33 +208,37 @@ namespace sio {
       }
     }
 
-    template <class Receiver>
-    void stop_receiver<Receiver>::set_value(stdexec::set_value_t) && noexcept {
+    template <class Completions, class Receiver>
+    void stop_receiver<Completions, Receiver>::set_value(stdexec::set_value_t) && noexcept {
       stdexec::set_value(std::move(op_->rcvr_));
     }
 
+    template <class Completions>
     struct subscribe_sequence {
       using is_sender = exec::sequence_tag;
       using completion_signatures = stdexec::completion_signatures<stdexec::set_value_t()>;
 
       template <class Receiver>
       auto subscribe(exec::subscribe_t, Receiver rcvr) const noexcept
-        -> subscribe_operation<Receiver> {
+        -> subscribe_operation<Completions, Receiver> {
         return {std::move(rcvr), channel_};
       }
 
-      handle_base channel_;
+      handle_base<Completions> channel_;
     };
 
+    template <class Completions>
     class channel;
 
+    template <class Completions>
     class handle {
      private:
-      handle_base base_;
+      handle_base<Completions> base_;
 
+      template <class>
       friend class channel;
 
-      explicit handle(context& ctx)
+      explicit handle(context<Completions>& ctx)
         : base_{&ctx} {
       }
 
@@ -240,26 +249,36 @@ namespace sio {
       }
 
      public:
-      notify_sender_t notify_all() {
-        return base_.notify_all();
+      template <class Sequence>
+      auto notify_all(Sequence&& seq) {
+        return sio::transform_each(
+                 std::forward<Sequence>(seq),
+                 [base = base_]<class Item>(Item&& item) {
+                   return base.notify_all(std::forward<Item>(item));
+                 })
+             | sio::ignore_all();
       }
 
-      subscribe_sequence subscribe() const noexcept {
+      subscribe_sequence<Completions> subscribe() const noexcept {
         return {base_};
       }
     };
 
+    template <class Completions>
     struct channel {
       auto open(async::open_t) const {
         return stdexec::let_value(
-          stdexec::just(make_deferred<context>()), [this](auto& ctx) noexcept {
+          stdexec::just(make_deferred<context<Completions>>()), [this](auto& ctx) noexcept {
             ctx();
-            return stdexec::just(handle{*ctx});
+            return stdexec::just(handle<Completions>{*ctx});
           });
       }
     };
   }
 
-  using async_channel = channel_::channel;
-  using async_channel_handle = channel_::handle;
+  template <class Completions>
+  using async_channel = channel_::channel<Completions>;
+
+  template <class Completions>
+  using async_channel_handle = channel_::handle<Completions>;
 }

--- a/source/sio/async_channel.hpp
+++ b/source/sio/async_channel.hpp
@@ -210,6 +210,7 @@ namespace sio {
 
     template <class Completions, class Receiver>
     void stop_receiver<Completions, Receiver>::set_value(stdexec::set_value_t) && noexcept {
+      op_->callback_.reset();
       stdexec::set_value(std::move(op_->rcvr_));
     }
 
@@ -249,8 +250,10 @@ namespace sio {
       }
 
      public:
+      handle() = default;
+
       template <class Sequence>
-      auto notify_all(Sequence&& seq) {
+      auto notify_all(Sequence&& seq) const {
         return sio::transform_each(
                  std::forward<Sequence>(seq),
                  [base = base_]<class Item>(Item&& item) {

--- a/source/sio/async_mutex.hpp
+++ b/source/sio/async_mutex.hpp
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2023 Maikel Nadolski
+ *
+ * Licensed under the Apache License Version 2.0 with LLVM Exceptions
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *   https://llvm.org/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <atomic>
+
+#include "./intrusive_queue.hpp"
+
+#include <exec/__detail/__atomic_intrusive_queue.hpp>
+#include <exec/any_sender_of.hpp>
+
+namespace sio {
+  namespace mutex_ {
+    struct operation_base {
+      operation_base* next = nullptr;
+      void (*complete)(operation_base*) noexcept = nullptr;
+    };
+
+    struct base {
+      std::atomic<bool> locked_{false};
+      exec::__atomic_intrusive_queue<&operation_base::next> inflight_operations_{};
+    };
+
+    template <class R>
+    struct lock_operation_base {
+      R rcvr_;
+    };
+
+    template <class Receiver>
+    struct lock_operation
+      : lock_operation_base<Receiver>
+      , operation_base {
+
+      base& base_;
+
+      static void on_complete(operation_base* op) noexcept {
+        auto* self = static_cast<lock_operation*>(op);
+        stdexec::set_value(std::move(self->rcvr_));
+      }
+
+      lock_operation(base& base, Receiver receiver)
+        : lock_operation_base<Receiver>{std::move(receiver)}
+        , operation_base{nullptr, &on_complete}
+        , base_{base} {
+      }
+
+      void start(stdexec::start_t) noexcept {
+        base& mutex = base_;
+        mutex.inflight_operations_.push_front(this);
+        bool expected_lock = false;
+        while (
+          mutex.locked_.compare_exchange_strong(expected_lock, true, std::memory_order_acq_rel)) {
+          auto pending_ops = mutex.inflight_operations_.pop_all();
+          while (!pending_ops.empty()) {
+            do {
+              operation_base* next = pending_ops.pop_front();
+              next->complete(next);
+            } while (!pending_ops.empty());
+            pending_ops = mutex.inflight_operations_.pop_all();
+          }
+          expected_lock = false;
+          mutex.locked_.store(false, std::memory_order_release);
+          if (mutex.inflight_operations_.empty()) {
+            break;
+          }
+        }
+      }
+    };
+
+    struct lock_sender {
+      using completion_signatures = stdexec::completion_signatures<stdexec::set_value_t()>;
+
+      base* mutex_;
+
+      template <class Receiver>
+      lock_operation<Receiver> connect(stdexec::connect_t, Receiver receiver) const noexcept {
+        return {*mutex_, std::move(receiver)};
+      }
+    };
+  }
+
+  struct async_mutex : mutex_::base {
+    mutex_::lock_sender lock() noexcept {
+      return {this};
+    }
+  };
+}

--- a/source/sio/async_resource.hpp
+++ b/source/sio/async_resource.hpp
@@ -325,13 +325,8 @@ namespace sio::async {
   struct use_resources_t {
     template <class Fn, class... DeferredResources>
     auto operator()(Fn&& fn, DeferredResources&&... resources) const {
-      return stdexec::let_value(
-        stdexec::just(static_cast<Fn&&>(fn), static_cast<DeferredResources&&>(resources)...),
-        []<class Fun, class... Deferred>(Fun&& fun, Deferred&... res) {
-          (res(), ...);
-          return sio::first(
-            sio::let_value_each(sio::zip(sio::async::run(*res)...), static_cast<Fun&&>(fun)));
-        });
+      return sio::first(
+        sio::let_value_each(sio::zip(sio::async::run(resources)...), static_cast<Fn&&>(fn)));
     }
   };
 

--- a/source/sio/intrusive_list.hpp
+++ b/source/sio/intrusive_list.hpp
@@ -19,8 +19,46 @@
 
 #include <tuple>
 #include <utility>
+#include <ranges>
 
 namespace sio {
+  template <auto Next>
+  struct intrusive_iterator;
+
+  template <class Item, Item* Item::*Next>
+  struct intrusive_iterator<Next>
+  {
+    using difference_type = std::ptrdiff_t;
+    Item* item_ = nullptr;
+
+    Item& operator*() const noexcept {
+      return *item_;
+    }
+
+    Item* operator->() const noexcept {
+      return item_;
+    }
+
+    intrusive_iterator& operator++() noexcept {
+      item_ = item_->*Next;
+      return *this;
+    }
+
+    intrusive_iterator operator++(int) noexcept {
+      intrusive_iterator copy{*this};
+      item_ = item_->*Next;
+      return copy;
+    }
+
+    friend bool operator==(const intrusive_iterator& lhs, const intrusive_iterator& rhs) noexcept {
+      return lhs.item_ == rhs.item_;
+    }
+
+    friend bool operator!=(const intrusive_iterator& lhs, const intrusive_iterator& rhs) noexcept {
+      return lhs.item_ != rhs.item_;
+    }
+  };
+
   template <auto Next, auto Prev>
   class intrusive_list;
 
@@ -38,6 +76,14 @@ namespace sio {
       std::swap(head_, other.head_);
       std::swap(tail_, other.tail_);
       return *this;
+    }
+
+    intrusive_iterator<Next> begin() const noexcept {
+      return intrusive_iterator<Next>{head_};
+    }
+
+    intrusive_iterator<Next> end() const noexcept {
+      return intrusive_iterator<Next>{};
     }
 
     [[nodiscard]] bool empty() const noexcept {

--- a/source/sio/net_concepts.hpp
+++ b/source/sio/net_concepts.hpp
@@ -557,4 +557,112 @@ namespace sio::async {
   }
 
   inline const accept_t accept{};
+
+  namespace sendmsg_ {
+    struct sendmsg_t;
+  };
+
+  using sendmsg_::sendmsg_t;
+  extern const sendmsg_t sendmsg;
+
+  namespace sendmsg_ {
+    template <class Tp, class... Args>
+    concept has_member_cpo = requires(Tp&& t, Args&&... args) {
+      static_cast<Tp&&>(t).sendmsg(sendmsg, static_cast<Args&&>(args)...);
+    };
+
+    template <class Tp, class... Args>
+    concept nothrow_has_member_cpo = requires(Tp&& t, Args&&... args) {
+      { static_cast<Tp&&>(t).sendmsg(sendmsg, static_cast<Args&&>(args)...) } noexcept;
+    };
+
+    template <class Tp, class... Args>
+    concept has_static_member_cpo = requires(Tp&& t, Args&&... args) {
+      decay_t<Tp>::sendmsg(static_cast<Tp&&>(t), sendmsg, static_cast<Args&&>(args)...);
+    };
+
+    template <class Tp, class... Args>
+    concept nothrow_has_static_member_cpo = requires(Tp&& t, Args&&... args) {
+      {
+        decay_t<Tp>::sendmsg(static_cast<Tp&&>(t), sendmsg, static_cast<Args&&>(args)...)
+      } noexcept;
+    };
+
+    template <class Tp, class... Args>
+    concept has_customization = has_member_cpo<Tp, Args...> || has_static_member_cpo<Tp, Args...>;
+
+    template <class Tp, class... Args>
+    concept nothrow_has_customization =
+      nothrow_has_member_cpo<Tp, Args...> || nothrow_has_static_member_cpo<Tp, Args...>;
+
+    struct sendmsg_t {
+      template <class Tp, class... Args>
+        requires has_customization<Tp, Args...>
+      auto operator()(Tp&& t, Args&&... args) const
+        noexcept(nothrow_has_customization<Tp, Args...>) {
+        if constexpr (has_member_cpo<Tp, Args...>) {
+          return static_cast<Tp&&>(t).sendmsg(sendmsg_t{}, static_cast<Args&&>(args)...);
+        } else {
+          return decay_t<Tp>::sendmsg(
+            static_cast<Tp&&>(t), sendmsg_t{}, static_cast<Args&&>(args)...);
+        }
+      }
+    };
+  }
+
+  inline const sendmsg_t sendmsg{};
+
+  namespace recvmsg_ {
+    struct recvmsg_t;
+  };
+
+  using recvmsg_::recvmsg_t;
+  extern const recvmsg_t recvmsg;
+
+  namespace recvmsg_ {
+    template <class Tp, class... Args>
+    concept has_member_cpo = requires(Tp&& t, Args&&... args) {
+      static_cast<Tp&&>(t).recvmsg(recvmsg, static_cast<Args&&>(args)...);
+    };
+
+    template <class Tp, class... Args>
+    concept nothrow_has_member_cpo = requires(Tp&& t, Args&&... args) {
+      { static_cast<Tp&&>(t).recvmsg(recvmsg, static_cast<Args&&>(args)...) } noexcept;
+    };
+
+    template <class Tp, class... Args>
+    concept has_static_member_cpo = requires(Tp&& t, Args&&... args) {
+      decay_t<Tp>::recvmsg(static_cast<Tp&&>(t), recvmsg, static_cast<Args&&>(args)...);
+    };
+
+    template <class Tp, class... Args>
+    concept nothrow_has_static_member_cpo = requires(Tp&& t, Args&&... args) {
+      {
+        decay_t<Tp>::recvmsg(static_cast<Tp&&>(t), recvmsg, static_cast<Args&&>(args)...)
+      } noexcept;
+    };
+
+    template <class Tp, class... Args>
+    concept has_customization = has_member_cpo<Tp, Args...> || has_static_member_cpo<Tp, Args...>;
+
+    template <class Tp, class... Args>
+    concept nothrow_has_customization =
+      nothrow_has_member_cpo<Tp, Args...> || nothrow_has_static_member_cpo<Tp, Args...>;
+
+    struct recvmsg_t {
+      template <class Tp, class... Args>
+        requires has_customization<Tp, Args...>
+      auto operator()(Tp&& t, Args&&... args) const
+        noexcept(nothrow_has_customization<Tp, Args...>) {
+        if constexpr (has_member_cpo<Tp, Args...>) {
+          return static_cast<Tp&&>(t).recvmsg(recvmsg_t{}, static_cast<Args&&>(args)...);
+        } else {
+          return decay_t<Tp>::recvmsg(
+            static_cast<Tp&&>(t), recvmsg_t{}, static_cast<Args&&>(args)...);
+        }
+      }
+    };
+  }
+
+  inline const recvmsg_t recvmsg{};
 }

--- a/source/sio/sequence/merge_each.hpp
+++ b/source/sio/sequence/merge_each.hpp
@@ -33,6 +33,18 @@ namespace sio {
       // std::optional<default_stop_callback_t> on_receiver_stopped_{};
     };
 
+    template <class Receiver>
+    struct error_visitor {
+      Receiver* receiver_;
+
+      template <class Error>
+      void operator()(Error&& error) const noexcept {
+        if constexpr (stdexec::__not_decays_to<Error, std::monostate>) {
+          stdexec::set_error(static_cast<Receiver&&>(*receiver_), static_cast<Error&&>(error));
+        }
+      }
+    };
+
     template <class Receiver, class ErrorsVariant>
     struct receiver {
       using is_receiver = void;
@@ -50,7 +62,8 @@ namespace sio {
           // op_->on_receiver_stopped_.reset();
           int error_emplaced = op_->error_emplaced_.load(std::memory_order_acquire);
           if (error_emplaced == 2) {
-            stdexec::set_error(static_cast<Receiver&&>(op_->receiver_), std::move(op_->errors_));
+            std::visit(
+              error_visitor<Receiver>{&op_->receiver_}, static_cast<ErrorsVariant&&>(op_->errors_));
           } else {
             exec::set_value_unless_stopped(static_cast<Receiver&&>(op_->receiver_));
           }
@@ -119,14 +132,230 @@ namespace sio {
       }
     };
 
+    template <class Env, class... Senders>
+    concept sequence_factory =                                              //
+      sizeof...(Senders) == 1 &&                                            //
+      stdexec::__single_typed_sender<stdexec::__mfront<Senders...>, Env> && //
+      exec::sequence_sender_in<stdexec::__single_sender_value_t<stdexec::__mfront<Senders...>>, Env>;
+
+    template <class ItemReceiver, class Receiver, class ErrorsVariant>
+    struct dynamic_item_operation_base {
+      [[no_unique_address]] ItemReceiver receiver_;
+      operation_base<Receiver, ErrorsVariant>* parent_;
+    };
+
+    template <class ItemReceiver, class Receiver, class ErrorsVariant>
+    struct dynamic_next_receiver {
+      using is_receiver = void;
+
+      dynamic_item_operation_base<ItemReceiver, Receiver, ErrorsVariant>* op_;
+
+      stdexec::env_of_t<ItemReceiver> get_env(stdexec::get_env_t) const noexcept {
+        return stdexec::get_env(op_->receiver_);
+      }
+
+      template <class Sender>
+      auto set_next(exec::set_next_t, Sender&& sender) {
+        return exec::set_next(op_->parent_->receiver_, static_cast<Sender&&>(sender));
+      }
+
+      void set_value(stdexec::set_value_t) && noexcept {
+        stdexec::set_value(static_cast<ItemReceiver&&>(op_->receiver_));
+      }
+
+      void set_stopped(stdexec::set_stopped_t) && noexcept {
+        stdexec::set_stopped(static_cast<ItemReceiver&&>(op_->receiver_));
+      }
+
+      template <class Error>
+      void set_error(stdexec::set_error_t, Error&& error) && noexcept {
+        stdexec::set_stopped(static_cast<ItemReceiver&&>(op_->receiver_));
+        // stdexec::set_error(static_cast<ItemReceiver&&>(op_->receiver_), static_cast<Error&&>(error));
+      }
+    };
+
+    template <class Item, class ItemReceiver, class Receiver, class ErrorsVariant>
+    struct subsequence_operation
+      : dynamic_item_operation_base<ItemReceiver, Receiver, ErrorsVariant> {
+
+      using Subsequence = stdexec::__single_sender_value_t<Item>;
+
+      std::optional<exec::subscribe_result_t<
+        Subsequence,
+        dynamic_next_receiver<ItemReceiver, Receiver, ErrorsVariant>>>
+        op_;
+
+      subsequence_operation(
+        ItemReceiver item_receiver,
+        operation_base<Receiver, ErrorsVariant>* parent)
+        : dynamic_item_operation_base< ItemReceiver, Receiver, ErrorsVariant>{
+          static_cast<ItemReceiver&&>(item_receiver),
+          parent} {
+      }
+    };
+
+    template <class Item, class ItemReceiver, class Receiver, class ErrorsVariant>
+    struct receive_subsequence {
+      using is_receiver = void;
+
+      subsequence_operation<Item, ItemReceiver, Receiver, ErrorsVariant>* op_;
+
+      stdexec::env_of_t<ItemReceiver> get_env(stdexec::get_env_t) const noexcept {
+        return stdexec::get_env(op_->receiver_);
+      }
+
+      template <class Subsequence>
+      void set_value(stdexec::set_value_t, Subsequence&& subsequence) && noexcept {
+        try {
+          auto& next_op = op_->op_.emplace(stdexec::__conv{[&] {
+            return exec::subscribe(
+              static_cast<Subsequence&&>(subsequence),
+              dynamic_next_receiver<ItemReceiver, Receiver, ErrorsVariant>{op_});
+          }});
+          stdexec::start(next_op);
+        } catch (...) {
+          // TODO
+          stdexec::set_stopped(static_cast<ItemReceiver&&>(op_->receiver_));
+        }
+      }
+
+      void set_stopped(stdexec::set_stopped_t) && noexcept {
+        stdexec::set_stopped(static_cast<ItemReceiver&&>(op_->receiver_));
+      }
+
+      template <class Error>
+      void set_error(stdexec::set_error_t, Error&& error) && noexcept {
+        stdexec::set_stopped(static_cast<ItemReceiver&&>(op_->receiver_));
+      }
+    };
+
+    template <class Item, class ItemReceiver, class Receiver, class ErrorsVariant>
+    struct dynamic_item_operation
+      : subsequence_operation<Item, ItemReceiver, Receiver, ErrorsVariant> {
+      stdexec::
+        connect_result_t<Item, receive_subsequence<Item, ItemReceiver, Receiver, ErrorsVariant>>
+          receive_op_;
+
+      dynamic_item_operation(
+        Item&& item,
+        ItemReceiver item_receiver,
+        operation_base<Receiver, ErrorsVariant>* parent)
+        : subsequence_operation<
+          Item,
+          ItemReceiver,
+          Receiver,
+          ErrorsVariant>{static_cast<ItemReceiver&&>(item_receiver), parent}
+        , receive_op_{stdexec::connect(
+            static_cast<Item&&>(item),
+            receive_subsequence<Item, ItemReceiver, Receiver, ErrorsVariant>{this})} {
+      }
+
+      void start(stdexec::start_t) noexcept {
+        stdexec::start(receive_op_);
+      }
+    };
+
+    template <class Subsequence, class Receiver, class ErrorsVariant>
+    struct dynamic_item_sender {
+      using is_sender = void;
+
+      using completion_signatures =
+        stdexec::completion_signatures<stdexec::set_value_t(), stdexec::set_stopped_t()>;
+
+      Subsequence subsequence_;
+      operation_base<Receiver, ErrorsVariant>* parent_;
+
+      template <decays_to<dynamic_item_sender> Self, class ItemReceiver>
+      static auto connect(Self&& self, stdexec::connect_t, ItemReceiver item_receiver)
+        -> dynamic_item_operation<
+          copy_cvref_t<Self, Subsequence>,
+          ItemReceiver,
+          Receiver,
+          ErrorsVariant> {
+        return {
+          static_cast<Self&&>(self).subsequence_,
+          static_cast<ItemReceiver&&>(item_receiver),
+          self.parent_};
+      }
+    };
+
+    template <class Receiver, class ErrorsVariant>
+    struct dynamic_receiver {
+      using is_receiver = void;
+
+      operation_base<Receiver, ErrorsVariant>* parent_;
+
+      auto get_env(stdexec::get_env_t) const noexcept -> stdexec::env_of_t<Receiver> {
+        return stdexec::get_env(parent_->receiver_);
+      }
+
+      template <class Subsequence>
+      auto set_next(exec::set_next_t, Subsequence&& subsequence) //
+        noexcept(nothrow_decay_copyable<Subsequence>)            //
+        -> dynamic_item_sender<Subsequence, Receiver, ErrorsVariant> {
+        return {static_cast<Subsequence&&>(subsequence), parent_};
+      }
+
+      void set_value(stdexec::set_value_t) && noexcept {
+        int error_emplaced = parent_->error_emplaced_.load(std::memory_order_acquire);
+        if (error_emplaced == 2) {
+          std::visit(
+            error_visitor<Receiver>{&parent_->receiver_},
+            static_cast<ErrorsVariant&&>(parent_->errors_));
+        } else {
+          stdexec::set_value(static_cast<Receiver&&>(parent_->receiver_));
+        }
+      }
+
+      void set_stopped(stdexec::set_stopped_t) && noexcept {
+        int error_emplaced = parent_->error_emplaced_.load(std::memory_order_acquire);
+        if (error_emplaced == 2) {
+          std::visit(
+            error_visitor<Receiver>{&parent_->receiver_},
+            static_cast<ErrorsVariant&&>(parent_->errors_));
+        } else {
+          exec::set_value_unless_stopped(static_cast<Receiver&&>(parent_->receiver_));
+        }
+      }
+
+      template <class Error>
+      void set_error(stdexec::set_error_t, Error&& error) && noexcept {
+        stdexec::set_error(
+          static_cast<Receiver&&>(parent_->receiver_), static_cast<Error&&>(error));
+      }
+    };
+
+    template <class Sender, class Receiver, class ErrorsVariant>
+    struct dynamic_operation : operation_base<Receiver, ErrorsVariant> {
+      exec::subscribe_result_t<Sender, dynamic_receiver<Receiver, ErrorsVariant>> op_;
+
+      dynamic_operation(Sender&& sndr, Receiver rcvr)
+        : operation_base<Receiver, ErrorsVariant>{0, static_cast<Receiver&&>(rcvr)}
+        , op_{exec::subscribe(
+            static_cast<Sender&&>(sndr),
+            dynamic_receiver<Receiver, ErrorsVariant>{this})} {
+      }
+
+      void start(stdexec::start_t) noexcept {
+        stdexec::start(op_);
+      }
+    };
+
     template <class... Senders>
     struct sender {
       using is_sender = exec::sequence_tag;
 
+
+      template <class Self, class Env>
+      using value_type_t =
+        stdexec::__single_sender_value_t<copy_cvref_t<Self, stdexec::__mfront<Senders...>>, Env>;
+
       std::tuple<Senders...> senders_;
 
       template <decays_to<sender> Self, class Receiver>
-      static auto subscribe(Self&& self, exec::subscribe_t, Receiver receiver) {
+        requires(!sequence_factory<stdexec::env_of_t<Receiver>, copy_cvref_t<Self, Senders>...>)
+      static auto subscribe(Self&& self, exec::subscribe_t, Receiver receiver)
+        -> operation<Receiver, copy_cvref_t<Self, Senders>...> {
         return std::apply(
           [&]<class... Sndrs>(Sndrs&&... sndrs) {
             return operation<Receiver, Sndrs...>{
@@ -135,10 +364,26 @@ namespace sio {
           static_cast<Self&&>(self).senders_);
       }
 
+      template <decays_to<sender> Self, class Receiver>
+        requires sequence_factory<stdexec::env_of_t<Receiver>, copy_cvref_t<Self, Senders>...>
+      static auto subscribe(Self&& self, exec::subscribe_t, Receiver receiver) //
+        -> dynamic_operation<
+          copy_cvref_t<Self, stdexec::__mfront<Senders...>>,
+          Receiver,
+          typename traits<Receiver, copy_cvref_t<Self, Senders>...>::errors_variant> {
+        return {std::get<0>(static_cast<Self&&>(self).senders_), static_cast<Receiver&&>(receiver)};
+      }
+
       template <decays_to<sender> Self, class Env>
+        requires(!sequence_factory<Env, copy_cvref_t<Self, Senders>...>)
       static auto get_completion_signatures(Self&&, stdexec::get_completion_signatures_t, Env&&)
         -> stdexec::__concat_completion_signatures_t<
           stdexec::completion_signatures_of_t<copy_cvref_t<Self, Senders>, Env>...>;
+
+      template <decays_to<sender> Self, class Env>
+        requires sequence_factory<Env, copy_cvref_t<Self, Senders>...>
+      static auto get_completion_signatures(Self&&, stdexec::get_completion_signatures_t, Env&&)
+        -> stdexec::completion_signatures_of_t<value_type_t<Self, Env>, Env>;
     };
 
     struct merge_each_t {
@@ -147,9 +392,14 @@ namespace sio {
         -> sender<decay_t<Senders>...> {
         return {{static_cast<Senders&&>(senders)...}};
       }
+
+      auto operator()() const noexcept -> binder_back<merge_each_t> {
+        return {{}, {}, {}};
+      }
     };
-  }
+  } // namespace merge_each_
 
   using merge_each_::merge_each_t;
+
   inline constexpr merge_each_t merge_each{};
 }

--- a/source/sio/tap.hpp
+++ b/source/sio/tap.hpp
@@ -3,6 +3,7 @@
 #include <stdexec/execution.hpp>
 
 #include "./concepts.hpp"
+#include "./sequence/sequence_concepts.hpp"
 
 namespace sio {
   namespace tap_ {
@@ -14,10 +15,8 @@ namespace sio {
         return stdexec::get_env(receiver_);
       }
 
-      template <class... Args>
-        requires callable<stdexec::set_value_t, Receiver&&, Args...>
-      void set_value(stdexec::set_value_t, Args&&... args) && noexcept {
-        stdexec::set_value(static_cast<Receiver&&>(receiver_), static_cast<Args&&>(args)...);
+      void set_value(stdexec::set_value_t) && noexcept {
+        stdexec::set_value(static_cast<Receiver&&>(receiver_));
       }
 
       template <class Error>
@@ -29,7 +28,7 @@ namespace sio {
       void set_stopped(stdexec::set_stopped_t) && noexcept
         requires callable<stdexec::set_stopped_t, Receiver&&>
       {
-        stdexec::set_stopped(static_cast<Receiver&&>(receiver_));
+        exec::set_value_unless_stopped(static_cast<Receiver&&>(receiver_));
       }
     };
 
@@ -37,6 +36,24 @@ namespace sio {
     struct operation_base {
       Receiver receiver_;
       stdexec::connect_result_t<FinalSender, receiver_ref<Receiver>> final_op_;
+      std::atomic<bool> success_{true};
+
+      template <class InitialSender>
+      auto make_initial_sender(InitialSender&& initial) {
+        return exec::set_next(
+          this->receiver_,
+          stdexec::let_stopped(
+            stdexec::let_error(
+              std::forward<InitialSender>(initial),
+              [this](auto error) {
+                this->success_.store(false, std::memory_order_relaxed);
+                return stdexec::just_error(std::move(error));
+              }),
+            [this] {
+              this->success_.store(false, std::memory_order_relaxed);
+              return stdexec::just_stopped();
+            }));
+      }
 
       operation_base(FinalSender&& final, Receiver receiver)
         : receiver_{static_cast<Receiver&&>(receiver)}
@@ -56,32 +73,38 @@ namespace sio {
       }
 
       void set_value(stdexec::set_value_t) && noexcept {
-        stdexec::start(op_->final_op_);
-      }
-
-      template <class Error>
-        requires callable<stdexec::set_error_t, Receiver&&, Error>
-      void set_error(stdexec::set_error_t, Error&& error) && noexcept {
-        stdexec::set_error(static_cast<Receiver&&>(op_->receiver_), static_cast<Error&&>(error));
+        if (op_->success_.load(std::memory_order_relaxed)) {
+          stdexec::start(op_->final_op_);
+        } else {
+          exec::set_value_unless_stopped(std::move(op_->receiver_));
+        }
       }
 
       void set_stopped(stdexec::set_stopped_t) && noexcept
         requires callable<stdexec::set_stopped_t, Receiver&&>
       {
-        stdexec::set_stopped(static_cast<Receiver&&>(op_->receiver_));
+        if (op_->success_.load(std::memory_order_relaxed)) {
+          stdexec::start(op_->final_op_);
+        } else {
+          exec::set_value_unless_stopped(std::move(op_->receiver_));
+        }
       }
     };
 
     template <class InitialSender, class FinalSender, class Receiver>
     struct operation : operation_base<FinalSender, Receiver> {
-      stdexec::connect_result_t<InitialSender, initial_receiver<FinalSender, Receiver>> first_op_;
+      using next_sender_t =
+        decltype(std::declval<operation_base<FinalSender, Receiver>&>().make_initial_sender(
+          std::declval<InitialSender>()));
+
+      stdexec::connect_result_t<next_sender_t, initial_receiver<FinalSender, Receiver>> first_op_;
 
       operation(InitialSender&& initial, FinalSender&& final, Receiver receiver)
         : operation_base<FinalSender, Receiver>(
           static_cast<FinalSender&&>(final),
           static_cast<Receiver&&>(receiver))
         , first_op_(stdexec::connect(
-            static_cast<InitialSender&&>(initial),
+            this->make_initial_sender(static_cast<InitialSender&&>(initial)),
             initial_receiver<FinalSender, Receiver>{this})) {
       }
 
@@ -91,14 +114,14 @@ namespace sio {
     };
 
     template <class InitialSender, class FinalSender>
-    struct sender {
-      using is_sender = void;
+    struct sequence {
+      using is_sender = exec::sequence_tag;
 
       InitialSender initial_;
       FinalSender final_;
 
-      template <decays_to<sender> Self, stdexec::receiver Receiver>
-      static auto connect(Self&& self, stdexec::connect_t, Receiver receiver)
+      template <decays_to<sequence> Self, stdexec::receiver Receiver>
+      static auto subscribe(Self&& self, exec::subscribe_t, Receiver receiver)
         -> operation<copy_cvref_t<Self, InitialSender>, copy_cvref_t<Self, FinalSender>, Receiver> {
         return {
           static_cast<Self&&>(self).initial_,
@@ -106,12 +129,12 @@ namespace sio {
           static_cast<Receiver&&>(receiver)};
       }
 
-      template <decays_to<sender> Self, class Env>
+      template <decays_to<sequence> Self, class Env>
       static auto get_completion_signatures(Self&&, stdexec::get_completion_signatures_t, Env&&)
         -> stdexec::__concat_completion_signatures_t<
-          stdexec::completion_signatures_of_t<copy_cvref_t<Self, FinalSender>, Env>,
+          stdexec::completion_signatures_of_t<copy_cvref_t<Self, InitialSender>, Env>,
           stdexec::__try_make_completion_signatures<
-            InitialSender,
+            FinalSender,
             Env,
             stdexec::completion_signatures<>,
             stdexec::__mconst<stdexec::completion_signatures<>>>>;
@@ -119,7 +142,7 @@ namespace sio {
 
     struct tap_t {
       template <class Initial, class Final>
-      sender<decay_t<Initial>, decay_t<Final>> operator()(Initial&& init, Final&& final) const {
+      sequence<decay_t<Initial>, decay_t<Final>> operator()(Initial&& init, Final&& final) const {
         return {static_cast<Initial&&>(init), static_cast<Final&&>(final)};
       }
     };

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -14,6 +14,8 @@ add_executable(test_sio
   test_async_resource.cpp
   test_file_handle.cpp
   test_async_accept.cpp
+  test_async_mutex.cpp
+  test_async_channel.cpp
   test_memory_pool.cpp
   test_tap.cpp
   net/test_address.cpp

--- a/tests/net/test_socket_handle.cpp
+++ b/tests/net/test_socket_handle.cpp
@@ -15,7 +15,7 @@ void sync_wait(exec::io_uring_context& context, Sender&& sender) {
 
 template <class Proto>
 auto make_deferred_socket(exec::io_uring_context* ctx, Proto proto) {
-  return sio::make_deferred<sio::io_uring::socket_resource<Proto>>(ctx, proto);
+  return sio::make_deferred<sio::io_uring::socket<Proto>>(ctx, proto);
 }
 
 TEST_CASE("socket_handle - Open a socket", "[socket_handle]") {

--- a/tests/net/test_socket_handle.cpp
+++ b/tests/net/test_socket_handle.cpp
@@ -13,14 +13,9 @@ void sync_wait(exec::io_uring_context& context, Sender&& sender) {
   stdexec::sync_wait(exec::when_any(std::forward<Sender>(sender), context.run(exec::until::stopped)));
 }
 
-template <class Proto>
-auto make_deferred_socket(exec::io_uring_context* ctx, Proto proto) {
-  return sio::make_deferred<sio::io_uring::socket<Proto>>(ctx, proto);
-}
-
 TEST_CASE("socket_handle - Open a socket", "[socket_handle]") {
   exec::io_uring_context context{};
-  auto socket = make_deferred_socket(&context, sio::ip::tcp::v4());
+  auto socket = sio::io_uring::socket(&context, sio::ip::tcp::v4());
   sync_wait(
     context,
     sio::async::use_resources(
@@ -34,8 +29,8 @@ TEST_CASE("socket_handle - Open a socket", "[socket_handle]") {
 TEST_CASE("socket_handle - Connect to localhost", "[socket_handle][connect]") {
   exec::io_uring_context context{};
   exec::single_thread_context thread{};
-  auto server = make_deferred_socket(&context, sio::ip::tcp::v4());
-  auto client = make_deferred_socket(&context, sio::ip::tcp::v4());
+  auto server = sio::io_uring::socket(&context, sio::ip::tcp::v4());
+  auto client = sio::io_uring::socket(&context, sio::ip::tcp::v4());
   sio::ip::endpoint ep{sio::ip::address_v4::loopback(), 4242};
   sync_wait(
     context,

--- a/tests/test_async_accept.cpp
+++ b/tests/test_async_accept.cpp
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2023 Maikel Nadolski
+ *
+ * Licensed under the Apache License Version 2.0 with LLVM Exceptions
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *   https://llvm.org/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 #include "sio/io_uring/file_handle.hpp"
 #include "sio/io_uring/socket_handle.hpp"
 #include "sio/ip/address.hpp"
@@ -51,13 +66,13 @@ TEST_CASE("async_accept should work", "[async_accept]") {
 
   stdexec::sender auto accept = sio::async::use_resources(
     [](auto acceptor) { return ignore_all(sio::async::accept(acceptor)); },
-    io_uring::make_deferred_acceptor(&ctx, ip::tcp::v4(), ip::endpoint{ip::address_v4::any(), 1080}));
+    io_uring::acceptor(&ctx, ip::tcp::v4(), ip::endpoint{ip::address_v4::any(), 1080}));
 
   stdexec::sender auto connect = async::use_resources(
     [](auto client) {
       return sio::async::connect(client, ip::endpoint{ip::address_v4::loopback(), 1080});
     },
-    sio::io_uring::make_deferred_socket(&ctx, ip::tcp::v4()));
+    sio::io_uring::socket(&ctx, ip::tcp::v4()));
 
   ::sync_wait(ctx, exec::when_any(accept, connect));
 }

--- a/tests/test_async_channel.cpp
+++ b/tests/test_async_channel.cpp
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2023 Maikel Nadolski
+ *
+ * Licensed under the Apache License Version 2.0 with LLVM Exceptions
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *   https://llvm.org/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <sio/async_channel.hpp>
+#include <sio/sequence/first.hpp>
+#include <catch2/catch.hpp>
+
+TEST_CASE("async_channel - just", "[async_channel]") {
+  sio::async_channel channel{};
+  bool is_read = false;
+  auto use = sio::async::use_resources([&](sio::async_channel_handle handle) {
+    auto read = handle.subscribe() //
+              | sio::first() //
+              | stdexec::then([&]() noexcept {
+                  is_read = true;
+                });
+    auto write = handle.notify_all();
+    return stdexec::when_all(read, write);
+  }, channel);
+
+  stdexec::sync_wait(use);
+
+  CHECK(is_read);
+}

--- a/tests/test_async_channel.cpp
+++ b/tests/test_async_channel.cpp
@@ -18,15 +18,16 @@
 #include <catch2/catch.hpp>
 
 TEST_CASE("async_channel - just", "[async_channel]") {
-  sio::async_channel channel{};
+  using Sigs = stdexec::completion_signatures<stdexec::set_value_t()>;
+  sio::async_channel<Sigs> channel{};
   bool is_read = false;
-  auto use = sio::async::use_resources([&](sio::async_channel_handle handle) {
+  auto use = sio::async::use_resources([&](sio::async_channel_handle<Sigs> handle) {
     auto read = handle.subscribe() //
               | sio::first() //
               | stdexec::then([&]() noexcept {
                   is_read = true;
                 });
-    auto write = handle.notify_all();
+    auto write = handle.notify_all(stdexec::just());
     return stdexec::when_all(read, write);
   }, channel);
 

--- a/tests/test_async_mutex.cpp
+++ b/tests/test_async_mutex.cpp
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2023 Maikel Nadolski
+ *
+ * Licensed under the Apache License Version 2.0 with LLVM Exceptions
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *   https://llvm.org/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <sio/async_mutex.hpp>
+
+#include <catch2/catch.hpp>
+
+TEST_CASE("async_mutex - lock is a sender", "[async_mutex]") {
+  sio::async_mutex mutex{};
+  bool check = false;
+  stdexec::sync_wait(mutex.lock() | stdexec::then([&] { check = true; }));
+  CHECK(check);
+}

--- a/tests/test_async_resource.cpp
+++ b/tests/test_async_resource.cpp
@@ -19,7 +19,7 @@
 #include <catch2/catch.hpp>
 
 struct Token {
-  auto close(sio::async::close_t) const noexcept { 
+  auto close(sio::async::close_t) const noexcept {
     return stdexec::just();
   }
 };
@@ -42,9 +42,7 @@ TEST_CASE("async_resource - sequence", "[async_resource]") {
 }
 
 TEST_CASE("async_resource - use_resources", "[async_resource]") {
-  auto sndr = sio::async::use_resources([](Token) {
-    return stdexec::just(42);
-  }, sio::make_deferred<Resource>());
+  auto sndr = sio::async::use_resources([](Token) { return stdexec::just(42); }, Resource());
   auto result = stdexec::sync_wait(sndr);
   CHECK(result);
   auto [value] = result.value();

--- a/tests/test_async_resource.cpp
+++ b/tests/test_async_resource.cpp
@@ -33,7 +33,7 @@ struct Resource {
 TEST_CASE("async_resource - sequence", "[async_resource]") {
   STATIC_REQUIRE(sio::async::with_open_and_close<Resource, stdexec::empty_env>);
   Resource res{};
-  auto seq = sio::async::run(res);
+  auto seq = sio::async::use(res);
   using sequence_t = decltype(seq);
   STATIC_REQUIRE(exec::sequence_sender_in<sequence_t, stdexec::empty_env>);
   STATIC_REQUIRE(exec::sequence_sender_to<sequence_t, any_receiver>);

--- a/tests/test_file_handle.cpp
+++ b/tests/test_file_handle.cpp
@@ -51,13 +51,13 @@ TEST_CASE("file_handle - Open a path", "[file_handle]") {
   sync_wait(
     context,
     sio::async::use_resources(
-      no_op_path, sio::defer(sio::async::open_path, scheduler, "/dev/null")));
+      no_op_path, sio::async::open_path(scheduler, "/dev/null")));
 }
 
 TEST_CASE("file_handle - Open a file to /dev/null", "[file_handle]") {
   exec::io_uring_context context{};
   sio::io_uring::io_scheduler scheduler{&context};
   using sio::async::mode;
-  auto file = sio::defer(sio::async::open_file, scheduler, "/dev/null", mode::read);
+  auto file = sio::async::open_file(scheduler, "/dev/null", mode::read);
   sync_wait(context, sio::async::use_resources(no_op_file, std::move(file)));
 }

--- a/tests/test_tap.cpp
+++ b/tests/test_tap.cpp
@@ -1,1 +1,36 @@
 #include "sio/tap.hpp"
+
+#include "sio/sequence/then_each.hpp"
+#include "sio/sequence/ignore_all.hpp"
+
+#include "catch2/catch.hpp"
+
+template <class F>
+auto just_invoke(F f) {
+  return stdexec::then(stdexec::just(), static_cast<F&&>(f));
+}
+
+TEST_CASE("tap - with senders") {
+  int opened = 0;
+  int closed = 0;
+  auto tap = sio::tap(
+    just_invoke([&] {
+      opened++;
+      return opened;
+    }),
+    just_invoke([&] { closed++; }));
+  using tap_t = decltype(tap);
+  STATIC_REQUIRE(stdexec::sender<tap_t>);
+  STATIC_REQUIRE(exec::sequence_sender<tap_t>);
+  CHECK(stdexec::sync_wait(
+    sio::then_each(
+      tap,
+      [&](int i) {
+        CHECK(i == 1);
+        CHECK(i == opened);
+        CHECK(closed == 0);
+      })
+    | sio::ignore_all()));
+  CHECK(opened == 1);
+  CHECK(closed == 1);
+}


### PR DESCRIPTION
- rename `async_resource` CPO `run` to `use`
- `async_resource` can be copy constructible
- implement `async_channel<Completions>`
- implement `async_mutex`
- implement a dynamic `merge_each`
- rename `socket_resource` to `socket`
- rename `acceptor_resource` to `acceptor`
- `tap` algorithm returns a sequence
- Fix `zip` for type erased input senders