### PR TITLE
Adjustments to latest NVIDIA/stdexec

### DIFF
--- a/cmake/FetchStdexec.cmake
+++ b/cmake/FetchStdexec.cmake
@@ -3,8 +3,8 @@ FetchContent_Declare(
   stdexec
   GIT_REPOSITORY https://github.com/NVIDIA/stdexec.git
 
-  # branch: main. date: 2024-08-13
-  GIT_TAG 54b38c99e8cbb348c1dd3508fa540728882247db
+  # branch: main. date: 2025-04-28
+  GIT_TAG b0b18b82e9a9166af7a51bceeb2d7229f7bef33d
 )
 
 set(STDEXEC_BUILD_EXAMPLES OFF CACHE BOOL "close stdexec examples")

--- a/source/sio/async_allocator.hpp
+++ b/source/sio/async_allocator.hpp
@@ -157,7 +157,7 @@ namespace sio::async {
       return {static_cast<Receiver&&>(rcvr), pointer_};
     }
 
-    auto get_env() const noexcept -> stdexec::empty_env {
+    auto get_env() const noexcept -> stdexec::env<> {
       return {};
     }
   };

--- a/source/sio/async_allocator.hpp
+++ b/source/sio/async_allocator.hpp
@@ -217,7 +217,7 @@ namespace sio::async {
     }
 
     auto operator()() const noexcept {
-      return stdexec::read(*this);
+      return stdexec::read_env(*this);
     }
   };
 

--- a/source/sio/async_channel.hpp
+++ b/source/sio/async_channel.hpp
@@ -113,7 +113,7 @@ namespace sio {
       using is_receiver = void;
       subscribe_operation<Completions, Receiver>* op_;
 
-      stdexec::empty_env get_env(stdexec::get_env_t) const noexcept {
+      stdexec::env<> get_env(stdexec::get_env_t) const noexcept {
         return {};
       }
 
@@ -123,7 +123,7 @@ namespace sio {
     struct nop_receiver {
       using is_receiver = void;
 
-      stdexec::empty_env get_env(stdexec::get_env_t) const noexcept {
+      stdexec::env<> get_env(stdexec::get_env_t) const noexcept {
         return {};
       }
 

--- a/source/sio/async_resource.hpp
+++ b/source/sio/async_resource.hpp
@@ -114,9 +114,12 @@ namespace sio::async {
   using token_of_t = stdexec::__single_sender_value_t<call_result_t<open_t, Resource&>, Env>;
 
   template <class Sndr, class Env = stdexec::env<>>
-  concept sender_of_void =                              //
-    stdexec::sender_of<Sndr, stdexec::set_value_t()> && //
-    stdexec::__single_value_sender<Sndr, Env>;
+  concept sender_of_void = stdexec::sender_of<Sndr, stdexec::set_value_t()> && requires {
+    typename stdexec::__value_types_t<
+      stdexec::__completion_signatures_of_t<Sndr, Env>,
+      stdexec::__msingle_or<void>,
+      stdexec::__msingle_or<void>>;
+  };
 
   template <class Resource, class Env = stdexec::env<>>
   concept with_open_and_close =

--- a/source/sio/async_resource.hpp
+++ b/source/sio/async_resource.hpp
@@ -113,12 +113,12 @@ namespace sio::async {
     requires with_open<Resource, Env>
   using token_of_t = stdexec::__single_sender_value_t<call_result_t<open_t, Resource&>, Env>;
 
-  template <class Sndr, class Env = stdexec::empty_env>
+  template <class Sndr, class Env = stdexec::env<>>
   concept sender_of_void =                              //
     stdexec::sender_of<Sndr, stdexec::set_value_t()> && //
     stdexec::__single_value_sender<Sndr, Env>;
 
-  template <class Resource, class Env = stdexec::empty_env>
+  template <class Resource, class Env = stdexec::env<>>
   concept with_open_and_close =
     with_open<Resource, Env> && requires(Resource& resource, token_of_t<Resource, Env>& token) {
       { close(token) } -> sender_of_void;
@@ -336,7 +336,7 @@ namespace sio::async {
     stdexec::__msingle_or<void>,
     stdexec::__q<stdexec::__msingle>>;
 
-  template <resource Resource, class Env = stdexec::empty_env>
+  template <resource Resource, class Env = stdexec::env<>>
   using resource_token_of_t = decay_t<single_item_value_t<call_result_t<use_t, Resource&>, Env>>;
 
   struct use_resources_t {

--- a/source/sio/io_concepts.hpp
+++ b/source/sio/io_concepts.hpp
@@ -70,10 +70,10 @@ namespace sio { namespace async {
     { handle.path() } -> std::convertible_to<std::filesystem::path>;
   };
 
-  template <class Res, class Env = stdexec::empty_env>
+  template <class Res, class Env = stdexec::env<>>
   concept path_resource = resource<Res> && path_handle<resource_token_of_t<Res, Env>>;
 
-  template <class Sender, class Tp, class Env = stdexec::empty_env>
+  template <class Sender, class Tp, class Env = stdexec::env<>>
   concept single_value_sender =                    //
     stdexec::__single_value_sender<Sender, Env> && //
     std::same_as<Tp, stdexec::__single_sender_value_t<Sender, Env>>;
@@ -412,7 +412,7 @@ namespace sio { namespace async {
   template <class _FileHandle>
   concept file_handle = path_handle<_FileHandle> && seekable_byte_stream<_FileHandle>;
 
-  template <class Res, class Env = stdexec::empty_env>
+  template <class Res, class Env = stdexec::env<>>
   concept file_resource = resource<Res> && file_handle<resource_token_of_t<Res, Env>>;
 
   namespace open_file_ {

--- a/source/sio/memory_pool.hpp
+++ b/source/sio/memory_pool.hpp
@@ -186,7 +186,7 @@ namespace sio {
     struct rcvr {
       using receiver_concept = stdexec::receiver_t;
 
-      auto get_env() const noexcept -> stdexec::empty_env {
+      auto get_env() const noexcept -> stdexec::env<> {
         return {};
       }
 

--- a/source/sio/sequence/first.hpp
+++ b/source/sio/sequence/first.hpp
@@ -280,7 +280,7 @@ namespace sio {
     };
 
     struct first_t {
-      template <exec::sequence_sender<stdexec::empty_env> Sender>
+      template <exec::sequence_sender<stdexec::env<>> Sender>
       auto operator()(Sender&& seq) const -> stdexec::__well_formed_sender auto {
         auto domain = stdexec::__get_early_domain(static_cast<Sender&&>(seq));
         return stdexec::transform_sender(

--- a/source/sio/sequence/last.hpp
+++ b/source/sio/sequence/last.hpp
@@ -296,7 +296,7 @@ namespace sio {
     };
 
     struct last_t {
-      template <exec::sequence_sender<empty_env> Sender>
+      template <exec::sequence_sender<stdexec::env<>> Sender>
       auto operator()(Sender&& seq) const
         noexcept(nothrow_decay_copyable<Sender>) -> stdexec::__well_formed_sender auto {
         auto domain = stdexec::__get_early_domain(static_cast<Sender&&>(seq));

--- a/source/sio/sequence/merge_each.hpp
+++ b/source/sio/sequence/merge_each.hpp
@@ -152,7 +152,7 @@ namespace sio {
         requires stdexec::__has_common_domain<Senders...>
       auto operator()(Senders&&... senders) const
         noexcept((nothrow_decay_copyable<Senders> && ...)) -> stdexec::__well_formed_sender auto {
-        auto domain = stdexec::__domain::__common_domain_t<Senders...>();
+        auto domain = stdexec::__common_domain_t<Senders...>();
         return stdexec::transform_sender(
           domain,
           exec::make_sequence_expr<merge_each_t>(

--- a/source/sio/sequence/merge_each.hpp
+++ b/source/sio/sequence/merge_each.hpp
@@ -149,7 +149,7 @@ namespace sio {
 
     struct merge_each_t {
       template <stdexec::sender... Senders>
-        requires stdexec::__domain::__has_common_domain<Senders...>
+        requires stdexec::__has_common_domain<Senders...>
       auto operator()(Senders&&... senders) const
         noexcept((nothrow_decay_copyable<Senders> && ...)) -> stdexec::__well_formed_sender auto {
         auto domain = stdexec::__domain::__common_domain_t<Senders...>();

--- a/source/sio/sequence/sequence_concepts.hpp
+++ b/source/sio/sequence/sequence_concepts.hpp
@@ -103,7 +103,7 @@ namespace exec {
     using namespace stdexec;
 
     struct get_sequence_env_t {
-      template <sequence_sender<empty_env> Sequence>
+      template <sequence_sender<stdexec::env<>> Sequence>
         requires tag_invocable<get_sequence_env_t, const Sequence&>
       constexpr tag_invoke_result_t< get_sequence_env_t, const Sequence&>
         operator()(const Sequence& seq) const noexcept {
@@ -111,14 +111,14 @@ namespace exec {
         return tag_invoke(*this, seq);
       }
 
-      template <sequence_sender<empty_env> Sequence>
+      template <sequence_sender<stdexec::env<>> Sequence>
         requires(!tag_invocable<get_sequence_env_t, const Sequence&>)
-      constexpr empty_env operator()(const Sequence& seq) const noexcept {
+      constexpr stdexec::env<> operator()(const Sequence& seq) const noexcept {
         return {};
       }
 
       template <sender Sequence>
-        requires(!sequence_sender<Sequence, empty_env>)
+        requires(!sequence_sender<Sequence, stdexec::env<>>)
       constexpr auto operator()(const Sequence& seq) const noexcept {
         return make_env(
           with(cardinality_t{}, std::integral_constant<size_t, 1>{}),

--- a/source/sio/sequence/zip.hpp
+++ b/source/sio/sequence/zip.hpp
@@ -558,7 +558,7 @@ namespace sio {
 
     struct zip_t {
       template <stdexec::sender... Senders>
-        requires stdexec::__domain::__has_common_domain<Senders...>
+        requires stdexec::__has_common_domain<Senders...>
       auto operator()(Senders&&... senders) const
         noexcept((nothrow_decay_copyable<Senders> && ...)) -> stdexec::__well_formed_sender auto {
         auto domain = stdexec::__domain::__common_domain_t<Senders...>();

--- a/source/sio/sequence/zip.hpp
+++ b/source/sio/sequence/zip.hpp
@@ -561,7 +561,7 @@ namespace sio {
         requires stdexec::__has_common_domain<Senders...>
       auto operator()(Senders&&... senders) const
         noexcept((nothrow_decay_copyable<Senders> && ...)) -> stdexec::__well_formed_sender auto {
-        auto domain = stdexec::__domain::__common_domain_t<Senders...>();
+        auto domain = stdexec::__common_domain_t<Senders...>();
         return stdexec::transform_sender(
           domain,
           exec::make_sequence_expr<zip_t>(stdexec::__{}, static_cast<Senders&&>(senders)...));

--- a/tests/common/test_receiver.hpp
+++ b/tests/common/test_receiver.hpp
@@ -20,7 +20,7 @@ struct any_sequence_receiver {
   void set_error(E&&) && noexcept {
   }
 
-  auto get_env() const noexcept -> stdexec::empty_env {
+  auto get_env() const noexcept -> stdexec::env<> {
     return {};
   }
 };
@@ -53,7 +53,7 @@ struct int_receiver {
   void set_error(E&&) noexcept {
   }
 
-  auto get_env() const noexcept -> stdexec::empty_env {
+  auto get_env() const noexcept -> stdexec::env<> {
     return {};
   }
 };

--- a/tests/sequence/test_fork.cpp
+++ b/tests/sequence/test_fork.cpp
@@ -89,8 +89,8 @@ TEST_CASE("fork - with then_each and ignore_all", "[sio][fork]") {
 // TODO: empty_sequence doesn't have item types now.
 // TEST_CASE("fork - with empty_sequence") {
 //   auto fork = sio::fork(sio::empty_sequence());
-//   using sigs = stdexec::completion_signatures_of_t<decltype(fork), stdexec::empty_env>;
-//   using items = exec::item_types_of_t<decltype(fork), stdexec::empty_env>;
+//   using sigs = stdexec::completion_signatures_of_t<decltype(fork), stdexec::env<>>;
+//   using items = exec::item_types_of_t<decltype(fork), stdexec::env<>>;
 //   using newSigs = stdexec::__concat_completion_signatures<stdexec::__with_exception_ptr, sigs>;
 //   sio::any_sequence_receiver_ref<newSigs>::any_sender<> seq = fork;
 // }

--- a/tests/sequence/test_ignore_all.cpp
+++ b/tests/sequence/test_ignore_all.cpp
@@ -24,7 +24,7 @@
 TEST_CASE("ignore_all - with just sender", "[sequence][ignore_all]") {
   auto ignore = sio::ignore_all(stdexec::just(42));
   using ignore_t = decltype(ignore);
-  using completion_sigs = stdexec::completion_signatures_of_t<ignore_t, stdexec::empty_env>;
+  using completion_sigs = stdexec::completion_signatures_of_t<ignore_t, stdexec::env<>>;
   STATIC_REQUIRE(
     stdexec::same_as<completion_sigs, stdexec::completion_signatures<stdexec::set_value_t()>>);
   REQUIRE(stdexec::sync_wait(ignore));
@@ -33,7 +33,7 @@ TEST_CASE("ignore_all - with just sender", "[sequence][ignore_all]") {
 TEST_CASE("ignore_all - with just_stopped sender", "[sequence][ignore_all]") {
   auto ignore = sio::ignore_all(stdexec::just_stopped());
   using ignore_t = decltype(ignore);
-  using completion_sigs = stdexec::completion_signatures_of_t<ignore_t, stdexec::empty_env>;
+  using completion_sigs = stdexec::completion_signatures_of_t<ignore_t, stdexec::env<>>;
   STATIC_REQUIRE(stdexec::same_as<
                  completion_sigs,
                  stdexec::completion_signatures<stdexec::set_value_t(), stdexec::set_stopped_t()>>);
@@ -43,7 +43,7 @@ TEST_CASE("ignore_all - with just_stopped sender", "[sequence][ignore_all]") {
 TEST_CASE("ignore_all - with just_error sender", "[sequence][ignore_all]") {
   auto ignore = sio::ignore_all(stdexec::just_error(42));
   using ignore_t = decltype(ignore);
-  using completion_sigs = stdexec::completion_signatures_of_t<ignore_t, stdexec::empty_env>;
+  using completion_sigs = stdexec::completion_signatures_of_t<ignore_t, stdexec::env<>>;
   STATIC_REQUIRE(
     stdexec::same_as<
       completion_sigs,

--- a/tests/sequence/test_merge_each.cpp
+++ b/tests/sequence/test_merge_each.cpp
@@ -28,7 +28,7 @@
 TEST_CASE("merge_each - just", "[sio][merge_each]") {
   auto merge = sio::merge_each(stdexec::just(42));
   using merge_t = decltype(merge);
-  using env = stdexec::empty_env;
+  using env = stdexec::env<>;
   STATIC_REQUIRE(stdexec::sender_in<merge_t, env>);
   STATIC_REQUIRE(exec::sequence_sender_in<merge_t, env>);
   STATIC_REQUIRE(exec::sequence_sender_to<merge_t, any_sequence_receiver>);

--- a/tests/test_async_accept.cpp
+++ b/tests/test_async_accept.cpp
@@ -47,7 +47,7 @@ TEST_CASE("async_accept concept", "[async_accept]") {
   io_uring::acceptor_handle acceptor{ctx, -1, ip::tcp::v4(), ep};
 
   auto sequence = sio::async::accept(acceptor);
-  STATIC_REQUIRE(exec::sequence_sender<decltype(sequence), stdexec::empty_env>);
+  STATIC_REQUIRE(exec::sequence_sender<decltype(sequence), stdexec::env<>>);
 
   auto op = exec::subscribe(std::move(sequence), any_sequence_receiver{});
   STATIC_REQUIRE(stdexec::operation_state<decltype(op)>);

--- a/tests/test_async_resource.cpp
+++ b/tests/test_async_resource.cpp
@@ -33,11 +33,11 @@ struct Resource {
 };
 
 TEST_CASE("async_resource - sequence", "[async_resource]") {
-  STATIC_REQUIRE(sio::async::with_open_and_close<Resource, stdexec::empty_env>);
+  STATIC_REQUIRE(sio::async::with_open_and_close<Resource, stdexec::env<>>);
   Resource res{};
   auto seq = sio::async::use(res);
   using sequence_t = decltype(seq);
-  STATIC_REQUIRE(exec::sequence_sender_in<sequence_t, stdexec::empty_env>);
+  STATIC_REQUIRE(exec::sequence_sender_in<sequence_t, stdexec::env<>>);
   STATIC_REQUIRE(exec::sequence_sender_to<sequence_t, any_sequence_receiver>);
   auto op = exec::subscribe(std::move(seq), any_sequence_receiver{});
   stdexec::start(op);

--- a/tests/test_tap.cpp
+++ b/tests/test_tap.cpp
@@ -21,7 +21,7 @@ TEST_CASE("tap - with senders") {
     just_invoke([&] { closed++; }));
   using tap_t = decltype(tap);
   STATIC_REQUIRE(stdexec::sender<tap_t>);
-  STATIC_REQUIRE(exec::sequence_sender<tap_t, stdexec::empty_env>);
+  STATIC_REQUIRE(exec::sequence_sender<tap_t, stdexec::env<>>);
   CHECK(stdexec::sync_wait(
     sio::then_each(
       std::move(tap),


### PR DESCRIPTION
Collection of adjustments for compiling senders-io with almost latest NVIDIA/stdexec (https://github.com/NVIDIA/stdexec/commit/b0b18b82e9a9166af7a51bceeb2d7229f7bef33d) if you want (did not use latest commit due to https://github.com/NVIDIA/stdexec/issues/1523).